### PR TITLE
Use try-with-resources for JDBC AutoCloseable resources

### DIFF
--- a/base-component/tools/screen/Tools/Entity/SqlRunner.xml
+++ b/base-component/tools/screen/Tools/Entity/SqlRunner.xml
@@ -29,7 +29,6 @@ along with this software (see the LICENSE.md file). If not, see
 
             ExecutionContext ec = context.ec
 
-            def rs = null
             outerColumnsList = new ArrayList<ArrayList<String>>()
             outerRecordsList = new ArrayList<ArrayList<ArrayList>>()
 
@@ -39,9 +38,8 @@ along with this software (see the LICENSE.md file). If not, see
             sql = ec.web.secureRequestParameters.get("sql")
             if (sql && groupName) {
                 messageList = []
-                Connection con = ec.entity.getConnection(groupName)
-                try {
-                    stmt = con.createStatement()
+                try (Connection con = ec.entity.getConnection(groupName);
+                    stmt = con.createStatement()) {
 
                     for(int i=0; i< 100; i++) {
                         // try get 100 ResultSets, avoid infinite loop
@@ -61,7 +59,7 @@ along with this software (see the LICENSE.md file). If not, see
                             records = new ArrayList<ArrayList>()
                             outerColumnsList.add(columns)
                             outerRecordsList.add(records)
-                            rs = stmt.getResultSet()
+                            try (rs = stmt.getResultSet()) {
                             if (rs != null) {
                                 rsmd = rs.getMetaData()
                                 columnCount = rsmd.getColumnCount()
@@ -77,13 +75,13 @@ along with this software (see the LICENSE.md file). If not, see
                                     for (i = 1; i <= columnCount; i++) record.add(rs.getObject(i))
                                     records.add(record)
                                 }
-                                rs.close()
 
                                 if (limitReached) {
                                     messageList.add(ec.resource.expand('Only showing first ${limit} rows.',''))
                                 } else {
                                     messageList.add(ec.resource.expand('Showing all ${records.size()} results.',''))
                                 }
+                            }
                             }
                         } else if ((rowsAffected = stmt.getUpdateCount()) != -1){
                             messageList.add(ec.resource.expand('Query altered ${rowsAffected} rows.',''))
@@ -94,9 +92,6 @@ along with this software (see the LICENSE.md file). If not, see
                 } catch (Exception e) {
                     messageList.add(e.toString())
                     ec.logger.log(200, "Error running SQL query in SqlRunner", e)
-                } finally {
-                    if (stmt != null) { try { stmt.close() } catch (Exception e) { /* Ignore */ } }
-                    if (con != null) { try { con.close() } catch (Exception e) { /* Ignore */ } }
                 }
             }
         ]]></script>

--- a/base-component/tools/screen/Tools/Entity/SqlScriptRunner.xml
+++ b/base-component/tools/screen/Tools/Entity/SqlScriptRunner.xml
@@ -29,7 +29,6 @@ along with this software (see the LICENSE.md file). If not, see
 
             ExecutionContext ec = context.ec
 
-            def rs = null
             int limitInt = 1
 
             // make sure SQL comes in secure parameter (body, etc no URL)
@@ -37,11 +36,9 @@ along with this software (see the LICENSE.md file). If not, see
             if (sqlScript && groupName) {
                 sqlList = sqlScript.split(';')
                 messageList = []
-                Connection con = ec.entity.getConnection(groupName)
-                try {
+                try (Connection con = ec.entity.getConnection(groupName)) {
                     for (sql in sqlList) {
-                        try {
-                            stmt = con.createStatement()
+                        try (stmt = con.createStatement()) {
 
                             boolean isResultSet = stmt.execute(sql as String)
 
@@ -53,11 +50,8 @@ along with this software (see the LICENSE.md file). If not, see
                             stmt.clearWarnings()
 
                             if (isResultSet) {
-                                rs = stmt.getResultSet()
-                                try {
+                                try (rs = stmt.getResultSet()) {
                                     // do stuff with result set (like displaying it see SqlRunner.xml)
-                                } finally {
-                                    rs.close()
                                 }
                             } else if ((rowsAffected = stmt.getUpdateCount()) != -1){
                                 messageList.add(ec.resource.expand('Query altered ${rowsAffected} rows.',''))
@@ -66,14 +60,9 @@ along with this software (see the LICENSE.md file). If not, see
                         } catch (Exception e) {
                             messageList.add(e.toString())
                             ec.logger.log(200, "Error running SQL query in SqlRunner", e)
-                        } finally {
-                            if (stmt != null) { try { stmt.close() } catch (Exception e) { /* Ignore */ } }
                         }
                     }
-                } finally {
-                    if (con != null) { try { con.close() } catch (Exception e) { /* Ignore */ } }
                 }
-
             }
         ]]></script>
     </actions>


### PR DESCRIPTION
    Refactored code to utilize try-with-resources for JDBC operations, ensuring
        automatic resource management (ARM) compliance. This change improves code
        readability and reliability by eliminating the need for explicit resource
        closure, reducing the risk of resource leaks.